### PR TITLE
Make box holding figure 1 taller so that distance always displays

### DIFF
--- a/Interactives/HR_Diagram.ipynb
+++ b/Interactives/HR_Diagram.ipynb
@@ -343,7 +343,7 @@
     "dist_control = widgets.VBox([dist_toggle, dist_selector], \n",
     "                            layout=widgets.Layout(align_content='center', align_items='center', \n",
     "                                          display='flex', \n",
-    "                                          flex_flow='column', height='300px', max_height='500px', \n",
+    "                                          flex_flow='column', height='400px', max_height='500px', \n",
     "                                          max_width='250px', min_height='50px', min_width='150px', \n",
     "                                          overflow_x='hidden', overflow_y='hidden', width='150px'))\n",
     "\n",


### PR DESCRIPTION
Figure 1 in the HR diagram lab does not display the distance range on Chrome. Increasing the height of the box that contains the slider fixes the issue for me.